### PR TITLE
feat: localtxsubmission client

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -57,6 +57,7 @@ type NodeConfig struct {
 	Address      string `yaml:"address"      envconfig:"CARDANO_NODE_SOCKET_TCP_HOST"`
 	Port         uint   `yaml:"port"         envconfig:"CARDANO_NODE_SOCKET_TCP_PORT"`
 	SocketPath   string `yaml:"socketPath"   envconfig:"CARDANO_NODE_SOCKET_PATH"`
+	Timeout      uint   `yaml:"timeout"      envconfig:"CARDANO_NODE_SOCKET_TIMEOUT"`
 }
 
 // Singleton config instance with default values
@@ -80,6 +81,7 @@ var globalConfig = &Config{
 	Node: NodeConfig{
 		Network:    "mainnet",
 		SocketPath: "/node-ipc/node.socket",
+		Timeout:    30,
 	},
 }
 

--- a/internal/node/localtxsubmission.go
+++ b/internal/node/localtxsubmission.go
@@ -1,0 +1,32 @@
+// Copyright 2024 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package node
+
+import (
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/protocol/localtxsubmission"
+
+	"github.com/blinklabs-io/cardano-node-api/internal/config"
+)
+
+func buildLocalTxSubmissionConfig() localtxsubmission.Config {
+	cfg := config.GetConfig()
+	return localtxsubmission.NewConfig(
+		localtxsubmission.WithTimeout(
+			time.Duration(cfg.Node.Timeout) * time.Second,
+		),
+	)
+}

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -29,6 +29,8 @@ func GetConnection() (*ouroboros.Connection, error) {
 	oConn, err := ouroboros.NewConnection(
 		ouroboros.WithNetworkMagic(uint32(cfg.Node.NetworkMagic)),
 		ouroboros.WithNodeToNode(false),
+		ouroboros.WithKeepAlive(true),
+		ouroboros.WithLocalTxSubmissionConfig(buildLocalTxSubmissionConfig()),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failure creating Ouroboros connection: %s", err)


### PR DESCRIPTION
Add a LocalTxSubmission client to the Ouorboros client connecting to the node. This also introduces a timeout parameter to the client to prevent blocking forever.