### PR TITLE
feat: node query timeout configuration

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,6 +56,7 @@ type NodeConfig struct {
 	NetworkMagic uint32 `yaml:"networkMagic" envconfig:"CARDANO_NODE_NETWORK_MAGIC"`
 	Address      string `yaml:"address"      envconfig:"CARDANO_NODE_SOCKET_TCP_HOST"`
 	Port         uint   `yaml:"port"         envconfig:"CARDANO_NODE_SOCKET_TCP_PORT"`
+	QueryTimeout uint   `yaml:"queryTimeout" envconfig:"CARDANO_NODE_SOCKET_QUERY_TIMEOUT"`
 	SocketPath   string `yaml:"socketPath"   envconfig:"CARDANO_NODE_SOCKET_PATH"`
 	Timeout      uint   `yaml:"timeout"      envconfig:"CARDANO_NODE_SOCKET_TIMEOUT"`
 }
@@ -79,9 +80,10 @@ var globalConfig = &Config{
 		ListenPort:    8081,
 	},
 	Node: NodeConfig{
-		Network:    "mainnet",
-		SocketPath: "/node-ipc/node.socket",
-		Timeout:    180,
+		Network:      "mainnet",
+		SocketPath:   "/node-ipc/node.socket",
+		QueryTimeout: 180,
+		Timeout:      5,
 	},
 }
 

--- a/internal/node/chainsync.go
+++ b/internal/node/chainsync.go
@@ -31,7 +31,7 @@ func buildChainSyncConfig() chainsync.Config {
 	cfg := config.GetConfig()
 	return chainsync.NewConfig(
 		chainsync.WithBlockTimeout(
-			time.Duration(cfg.Node.Timeout) * time.Second,
+			time.Duration(cfg.Node.QueryTimeout) * time.Second,
 		),
 		chainsync.WithRollBackwardFunc(chainSyncRollBackwardHandler),
 		chainsync.WithRollForwardFunc(chainSyncRollForwardHandler),

--- a/internal/node/localtxmonitor.go
+++ b/internal/node/localtxmonitor.go
@@ -29,7 +29,7 @@ func buildLocalTxMonitorConfig() localtxmonitor.Config {
 			time.Duration(cfg.Node.Timeout) * time.Second,
 		),
 		localtxmonitor.WithQueryTimeout(
-			time.Duration(cfg.Node.Timeout) * time.Second,
+			time.Duration(cfg.Node.QueryTimeout) * time.Second,
 		),
 	)
 }

--- a/internal/node/localtxsubmission.go
+++ b/internal/node/localtxsubmission.go
@@ -26,7 +26,7 @@ func buildLocalTxSubmissionConfig() localtxsubmission.Config {
 	cfg := config.GetConfig()
 	return localtxsubmission.NewConfig(
 		localtxsubmission.WithTimeout(
-			time.Duration(cfg.Node.Timeout) * time.Second,
+			time.Duration(cfg.Node.QueryTimeout) * time.Second,
 		),
 	)
 }


### PR DESCRIPTION
Split the normal node timeout from the node query timeout, so we can have more aggressive values on the primary timeout while being more lenient on the query timeout.