### PR TITLE
feat: localstatequery rest endpoints (part 2)

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -49,6 +49,81 @@ const docTemplate = `{
                 }
             }
         },
+        "/localstatequery/era-history": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "localstatequery"
+                ],
+                "summary": "Query Era History",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.responseLocalStateQueryEraHistory"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.responseApiError"
+                        }
+                    }
+                }
+            }
+        },
+        "/localstatequery/genesis-config": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "localstatequery"
+                ],
+                "summary": "Query Genesis Config",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.responseLocalStateQueryGenesisConfig"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.responseApiError"
+                        }
+                    }
+                }
+            }
+        },
+        "/localstatequery/protocol-params": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "localstatequery"
+                ],
+                "summary": "Query Current Protocol Parameters",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.responseLocalStateQueryProtocolParams"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.responseApiError"
+                        }
+                    }
+                }
+            }
+        },
         "/localstatequery/system-start": {
             "get": {
                 "produces": [
@@ -254,6 +329,15 @@ const docTemplate = `{
                     "type": "string"
                 }
             }
+        },
+        "api.responseLocalStateQueryEraHistory": {
+            "type": "object"
+        },
+        "api.responseLocalStateQueryGenesisConfig": {
+            "type": "object"
+        },
+        "api.responseLocalStateQueryProtocolParams": {
+            "type": "object"
         },
         "api.responseLocalStateQuerySystemStart": {
             "type": "object",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -45,6 +45,81 @@
                 }
             }
         },
+        "/localstatequery/era-history": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "localstatequery"
+                ],
+                "summary": "Query Era History",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.responseLocalStateQueryEraHistory"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.responseApiError"
+                        }
+                    }
+                }
+            }
+        },
+        "/localstatequery/genesis-config": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "localstatequery"
+                ],
+                "summary": "Query Genesis Config",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.responseLocalStateQueryGenesisConfig"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.responseApiError"
+                        }
+                    }
+                }
+            }
+        },
+        "/localstatequery/protocol-params": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "localstatequery"
+                ],
+                "summary": "Query Current Protocol Parameters",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.responseLocalStateQueryProtocolParams"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.responseApiError"
+                        }
+                    }
+                }
+            }
+        },
         "/localstatequery/system-start": {
             "get": {
                 "produces": [
@@ -250,6 +325,15 @@
                     "type": "string"
                 }
             }
+        },
+        "api.responseLocalStateQueryEraHistory": {
+            "type": "object"
+        },
+        "api.responseLocalStateQueryGenesisConfig": {
+            "type": "object"
+        },
+        "api.responseLocalStateQueryProtocolParams": {
+            "type": "object"
         },
         "api.responseLocalStateQuerySystemStart": {
             "type": "object",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -13,6 +13,12 @@ definitions:
       name:
         type: string
     type: object
+  api.responseLocalStateQueryEraHistory:
+    type: object
+  api.responseLocalStateQueryGenesisConfig:
+    type: object
+  api.responseLocalStateQueryProtocolParams:
+    type: object
   api.responseLocalStateQuerySystemStart:
     properties:
       day:
@@ -87,6 +93,54 @@ paths:
           schema:
             $ref: '#/definitions/api.responseApiError'
       summary: Query Current Era
+      tags:
+      - localstatequery
+  /localstatequery/era-history:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.responseLocalStateQueryEraHistory'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.responseApiError'
+      summary: Query Era History
+      tags:
+      - localstatequery
+  /localstatequery/genesis-config:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.responseLocalStateQueryGenesisConfig'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.responseApiError'
+      summary: Query Genesis Config
+      tags:
+      - localstatequery
+  /localstatequery/protocol-params:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.responseLocalStateQueryProtocolParams'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.responseApiError'
+      summary: Query Current Protocol Parameters
       tags:
       - localstatequery
   /localstatequery/system-start:

--- a/internal/api/localstatequery.go
+++ b/internal/api/localstatequery.go
@@ -28,6 +28,11 @@ func configureLocalStateQueryRoutes(apiGroup *gin.RouterGroup) {
 	group.GET("/current-era", handleLocalStateQueryCurrentEra)
 	group.GET("/system-start", handleLocalStateQuerySystemStart)
 	group.GET("/tip", handleLocalStateQueryTip)
+	group.GET("/era-history", handleLocalStateQueryEraHistory)
+	group.GET("/protocol-params", handleLocalStateQueryProtocolParams)
+	// TODO: uncomment after this is fixed:
+	// - https://github.com/blinklabs-io/gouroboros/issues/584
+	// group.GET("/genesis-config", handleLocalStateQueryGenesisConfig)
 }
 
 type responseLocalStateQueryCurrentEra struct {
@@ -209,4 +214,149 @@ func handleLocalStateQueryTip(c *gin.Context) {
 		Hash:    hex.EncodeToString(point.Hash),
 	}
 	c.JSON(200, resp)
+}
+
+//nolint:unused
+// TODO: fill this in
+type responseLocalStateQueryEraHistory struct {
+}
+
+// handleLocalStateQueryEraHistory godoc
+//
+//	@Summary	Query Era History
+//	@Tags		localstatequery
+//	@Produce	json
+//	@Success	200	{object}	responseLocalStateQueryEraHistory
+//	@Failure	500	{object}	responseApiError
+//	@Router		/localstatequery/era-history [get]
+func handleLocalStateQueryEraHistory(c *gin.Context) {
+	// Connect to node
+	oConn, err := node.GetConnection()
+	if err != nil {
+		c.JSON(500, apiError(err.Error()))
+		return
+	}
+	// Async error handler
+	go func() {
+		err, ok := <-oConn.ErrorChan()
+		if !ok {
+			return
+		}
+		c.JSON(500, apiError(err.Error()))
+	}()
+	defer func() {
+		// Close Ouroboros connection
+		oConn.Close()
+	}()
+	// Start client
+	oConn.LocalStateQuery().Client.Start()
+
+	// Get eraHistory
+	eraHistory, err := oConn.LocalStateQuery().Client.GetEraHistory()
+	if err != nil {
+		c.JSON(500, apiError(err.Error()))
+		return
+	}
+
+	// Create response
+	//resp := responseLocalStateQueryProtocolParams{
+	//}
+	c.JSON(200, eraHistory)
+}
+
+//nolint:unused
+// TODO: fill this in
+type responseLocalStateQueryProtocolParams struct {
+}
+
+// handleLocalStateQueryProtocolParams godoc
+//
+//	@Summary	Query Current Protocol Parameters
+//	@Tags		localstatequery
+//	@Produce	json
+//	@Success	200	{object}	responseLocalStateQueryProtocolParams
+//	@Failure	500	{object}	responseApiError
+//	@Router		/localstatequery/protocol-params [get]
+func handleLocalStateQueryProtocolParams(c *gin.Context) {
+	// Connect to node
+	oConn, err := node.GetConnection()
+	if err != nil {
+		c.JSON(500, apiError(err.Error()))
+		return
+	}
+	// Async error handler
+	go func() {
+		err, ok := <-oConn.ErrorChan()
+		if !ok {
+			return
+		}
+		c.JSON(500, apiError(err.Error()))
+	}()
+	defer func() {
+		// Close Ouroboros connection
+		oConn.Close()
+	}()
+	// Start client
+	oConn.LocalStateQuery().Client.Start()
+
+	// Get protoParams
+	protoParams, err := oConn.LocalStateQuery().Client.GetCurrentProtocolParams()
+	if err != nil {
+		c.JSON(500, apiError(err.Error()))
+		return
+	}
+
+	// Create response
+	//resp := responseLocalStateQueryProtocolParams{
+	//}
+	c.JSON(200, protoParams)
+}
+
+//nolint:unused
+// TODO: fill this in
+type responseLocalStateQueryGenesisConfig struct {
+}
+
+//nolint:unused
+// handleLocalStateQueryGenesisConfig godoc
+//
+//	@Summary	Query Genesis Config
+//	@Tags		localstatequery
+//	@Produce	json
+//	@Success	200	{object}	responseLocalStateQueryGenesisConfig
+//	@Failure	500	{object}	responseApiError
+//	@Router		/localstatequery/genesis-config [get]
+func handleLocalStateQueryGenesisConfig(c *gin.Context) {
+	// Connect to node
+	oConn, err := node.GetConnection()
+	if err != nil {
+		c.JSON(500, apiError(err.Error()))
+		return
+	}
+	// Async error handler
+	go func() {
+		err, ok := <-oConn.ErrorChan()
+		if !ok {
+			return
+		}
+		c.JSON(500, apiError(err.Error()))
+	}()
+	defer func() {
+		// Close Ouroboros connection
+		oConn.Close()
+	}()
+	// Start client
+	oConn.LocalStateQuery().Client.Start()
+
+	// Get genesisConfig
+	genesisConfig, err := oConn.LocalStateQuery().Client.GetGenesisConfig()
+	if err != nil {
+		c.JSON(500, apiError(err.Error()))
+		return
+	}
+
+	// Create response
+	//resp := responseLocalStateQueryGenesisConfig{
+	//}
+	c.JSON(200, genesisConfig)
 }


### PR DESCRIPTION
This implements several queries from LocalStateQuery Ouroboros mini-protocol.

- era-history - returns the era begin/end and timing parameters
- protocol-params - returns the current protocol parameters
- genesis-config - returns the genesis config (not routed due to blinklabs-io/gouroboros#584)