### PR TITLE
docs(openapi): remove scheme for dynamic support

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -472,7 +472,7 @@ var SwaggerInfo = &swag.Spec{
 	Version:          "1.0",
 	Host:             "",
 	BasePath:         "/api",
-	Schemes:          []string{"http"},
+	Schemes:          []string{},
 	Title:            "cardano-node-api",
 	Description:      "Cardano Node API",
 	InfoInstanceName: "swagger",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1,7 +1,4 @@
 {
-    "schemes": [
-        "http"
-    ],
     "swagger": "2.0",
     "info": {
         "description": "Cardano Node API",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -296,6 +296,4 @@ paths:
           schema:
             type: string
       summary: Submit Tx
-schemes:
-- http
 swagger: "2.0"

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -33,7 +33,6 @@ import (
 // @title			cardano-node-api
 // @version		1.0
 // @description	Cardano Node API
-// @Schemes		http
 // @BasePath		/api
 // @contact.name	Blink Labs
 // @contact.url	https://blinklabs.io


### PR DESCRIPTION
With this removed, the `/swagger/index.html` page will generate links using the existing scheme, so it works over http or https.