### PR TITLE
fix: followTip api call

### DIFF
--- a/internal/utxorpc/sync.go
+++ b/internal/utxorpc/sync.go
@@ -193,9 +193,8 @@ func (s *chainSyncServiceServer) FollowTip(
 			blockIdx := blockRef.GetIndex()
 			blockHash := blockRef.GetHash()
 			log.Printf("BlockRef: idx: %d, hash: %x", blockIdx, blockHash)
-			hash, _ := hex.DecodeString(string(blockHash))
 			slot := uint64(blockIdx)
-			point = ocommon.NewPoint(slot, hash)
+			point = ocommon.NewPoint(slot, blockHash)
 		}
 	} else {
 		tip, _ := oConn.ChainSync().Client.GetCurrentTip()


### PR DESCRIPTION
It was silently failing during unneeded conversion and giving an empty `hash`.

Casting hex bytes to string doesn't work. If we need it, we should use `hex.EncodeToString()`

Logs

```
2024/09/29 04:22:29 Got a FollowTip request with intersect [index:25980880 hash:"{;&Ow\x1e\x9e\x18\xb6\x83\xfc\xebS\xba\xbf\xd0a\xc0\x9a\x88\xca\xceqZiM\xd7\xf7Q\xe2\xa4p"]
2024/09/29 04:22:29 BlockRef: idx: 25980880, hash: 7b3b264f771e9e18b683fceb53babfd061c09a88cace715a694dd7f751e2a470
2024/09/29 04:22:31 block: slot: 25980913, hash: e02d8b7d7a88e4026066d414685e8c2de02ceaf5eaa1ac891a1f8043e113ba82
2024/09/29 04:22:31 block: slot: 25980988, hash: 4049ab001f9691fc49979165617e1c45dc0857ef1246aa479fd782a37080b647
2024/09/29 04:22:31 block: slot: 25980999, hash: cebfd69916c64405bc74e6c8c1f47f0c76beb97a71e56cdd95433e26e81ced0d
```