### PR TITLE
fix(utorpc): pass mux handler

### DIFF
--- a/internal/utxorpc/api.go
+++ b/internal/utxorpc/api.go
@@ -112,7 +112,7 @@ func Start(cfg *config.Config) error {
 			),
 			cfg.Tls.CertFilePath,
 			cfg.Tls.KeyFilePath,
-			nil,
+			mux,
 		)
 		return err
 	} else {


### PR DESCRIPTION

logs
```
{"level":"info","timestamp":"2024-10-23T01:23:53Z","caller":"api/api.go:107","msg":"starting metrics listener on :8082"}
2024/10/23 01:24:02 Got a FollowTip request with intersect [index:137750635  hash:"$l0|\x9e9\xc5\xd5\xefps&\xa9x\xc3SK\x0c\x97J\x80A\xa3\x8d\xa3\x18}\xbbFq\xaf\xae"]
2024/10/23 01:24:02 BlockRef: idx: 137750635, hash: 246c307c9e39c5d5ef707326a978c3534b0c974a8041a38da3187dbb4671afae
```