### PR TITLE
chore: update go version to 1.25

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -16,7 +16,7 @@ jobs:
     name: go-test
     strategy:
       matrix:
-        go-version: [1.24.x, 1.25.x]
+        go-version: [1.25.x, 1.26.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,9 +2,9 @@ name: publish
 
 on:
   push:
-    branches: ['main']
+    branches: ["main"]
     tags:
-      - 'v*.*.*'
+      - "v*.*.*"
 
 concurrency: ${{ github.ref }}
 
@@ -16,7 +16,7 @@ jobs:
     outputs:
       RELEASE_ID: ${{ steps.create-release.outputs.result }}
     steps:
-      - run: "echo \"RELEASE_TAG=${GITHUB_REF#refs/tags/}\" >> $GITHUB_ENV"
+      - run: 'echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV'
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0 https://github.com/actions/github-script/releases/tag/v9.0.0
         id: create-release
         if: startsWith(github.ref, 'refs/tags/')
@@ -56,13 +56,13 @@ jobs:
       packages: write
       statuses: write
     steps:
-      - run: "echo \"RELEASE_TAG=${GITHUB_REF#refs/tags/}\" >> $GITHUB_ENV"
+      - run: 'echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV'
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
         with:
-          fetch-depth: '0'
+          fetch-depth: "0"
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0 https://github.com/actions/setup-go/releases/tag/v6.4.0
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
       - name: Build binary
         run: GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} make build
       - name: Upload release asset
@@ -81,7 +81,7 @@ jobs:
       - name: Attest binary
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0 https://github.com/actions/attest/releases/tag/v4.1.0
         with:
-          subject-path: 'cardano-node-api'
+          subject-path: "cardano-node-api"
 
   build-images:
     runs-on: ubuntu-latest
@@ -95,10 +95,10 @@ jobs:
       packages: write
       statuses: write
     steps:
-      - run: "echo \"RELEASE_TAG=${GITHUB_REF#refs/tags/}\" >> $GITHUB_ENV"
+      - run: 'echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV'
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
         with:
-          fetch-depth: '0'
+          fetch-depth: "0"
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0 https://github.com/docker/setup-qemu-action/releases/tag/v4.0.0
       - name: Set up Docker Buildx

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/blinklabs-io/cardano-node-api
 
-go 1.25
+go 1.25.0
+
+toolchain go1.25.7
 
 require (
 	connectrpc.com/connect v1.19.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/blinklabs-io/cardano-node-api
 
-go 1.25.7
+go 1.25
 
 require (
 	connectrpc.com/connect v1.19.2

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/blinklabs-io/cardano-node-api
 
-go 1.24.0
-
-toolchain go1.24.1
+go 1.25.7
 
 require (
 	connectrpc.com/connect v1.19.2


### PR DESCRIPTION
Closes #567

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update project to Go 1.25 and drop 1.24 support (closes #567). `go.mod` now sets `go 1.25.0` and updates the `toolchain` to `go1.25.7`; CI tests run on 1.25/1.26, and the publish workflow builds with 1.25.x.

- **Migration**
  - Use Go 1.25+ locally to build and run the project.

<sup>Written for commit 3e56ac631de489e675f46328130173bbb9afd5eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go version requirements to 1.25.x and 1.26.x across build and test pipelines.
  * Refreshed CI/CD workflow configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/cardano-node-api/pull/579)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->