### PR TITLE
chore: replace inline workflows with reusable workflow wrappers

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -7,9 +7,11 @@ on:
       - main
     paths:
       - Dockerfile
+      - Makefile
       - cmd/**
       - docs/**
       - internal/**
+      - openapi/**
       - go.*
       - .github/workflows/ci-docker.yml
 

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -1,37 +1,20 @@
-name: Docker CI
+# Generated automatically by org-governance-bot. Do not edit manually.
+name: "Docker CI"
 
 on:
   pull_request:
-    branches: ['main']
-    paths: ['Dockerfile','cmd/**','docs/**','internal/**','go.*','.github/workflows/ci-docker.yml']
-
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: blinklabs/cardano-node-api
-
-permissions:
-  contents: read
+    branches:
+      - main
+    paths:
+      - Dockerfile
+      - cmd/**
+      - docs/**
+      - internal/**
+      - go.*
+      - .github/workflows/ci-docker.yml
 
 jobs:
-  docker:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3 https://github.com/actions/checkout/releases/tag/v6.0.3
-        with:
-          fetch-depth: '0'
-      - name: qemu
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0 https://github.com/docker/setup-qemu-action/releases/tag/v4.1.0
-      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0 https://github.com/docker/setup-buildx-action/releases/tag/v4.1.0
-      - id: meta
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0 https://github.com/docker/metadata-action/releases/tag/v6.1.0
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-      - name: build
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0 https://github.com/docker/build-push-action/releases/tag/v7.2.0
-        with:
-          context: .
-          push: false
-          ### TODO: test multiple platforms
-          # platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+  orchestrate:
+    uses: blinklabs-io/actions/.github/workflows/reuseable-ci-docker.yml@main
+    with:
+      image-name: blinklabs-io/cardano-node-api

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,17 +1,9 @@
-# The below is pulled from upstream and slightly modified
-# https://github.com/webiny/action-conventional-commits/blob/master/README.md#usage
-
-name: Conventional Commits
+# Generated automatically by org-governance-bot. Do not edit manually.
+name: "Conventional Commits"
 
 on:
   pull_request:
 
 jobs:
-  build:
-    name: Conventional Commits
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3 https://github.com/actions/checkout/releases/tag/v6.0.3
-      - uses: webiny/action-conventional-commits@7f91b1595ca1951cdb671ddc9f07a49081ec5b69 # v1.4.2 https://github.com/webiny/action-conventional-commits/releases/tag/v1.4.2
+  orchestrate:
+    uses: blinklabs-io/actions/.github/workflows/reuseable-conventional-commits.yml@main

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,28 +1,14 @@
-name: go-test
+# Generated automatically by org-governance-bot. Do not edit manually.
+name: "go-test"
 
 on:
+  pull_request:
   push:
-    tags:
-      - v*
     branches:
       - main
-  pull_request:
-
-permissions:
-  contents: read
+    tags:
+      - v*
 
 jobs:
-  go-test:
-    name: go-test
-    strategy:
-      matrix:
-        go-version: [1.25.x, 1.26.x]
-        platform: [ubuntu-latest]
-    runs-on: ${{ matrix.platform }}
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3 https://github.com/actions/checkout/releases/tag/v6.0.3
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0 https://github.com/actions/setup-go/releases/tag/v6.4.0
-        with:
-          go-version: ${{ matrix.go-version }}
-      - name: go-test
-        run: go test ./...
+  orchestrate:
+    uses: blinklabs-io/actions/.github/workflows/reuseable-go-test.yml@main

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,23 +1,14 @@
-name: golangci-lint
+# Generated automatically by org-governance-bot. Do not edit manually.
+name: "golangci-lint"
+
 on:
+  pull_request:
   push:
-    tags:
-      - v*
     branches:
       - main
-  pull_request:
-
-permissions:
-  contents: read
+    tags:
+      - v*
 
 jobs:
-  golangci:
-    name: lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3 https://github.com/actions/checkout/releases/tag/v6.0.3
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0 https://github.com/actions/setup-go/releases/tag/v6.4.0
-        with:
-          go-version: 1.25.x
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1 https://github.com/golangci/golangci-lint-action/releases/tag/v9.2.1
+  orchestrate:
+    uses: blinklabs-io/actions/.github/workflows/reuseable-golangci-lint.yml@main

--- a/.github/workflows/nilaway.yml
+++ b/.github/workflows/nilaway.yml
@@ -1,25 +1,16 @@
-name: nilaway
+# Generated automatically by org-governance-bot. Do not edit manually.
+name: "nilaway"
+
 on:
+  pull_request:
   push:
-    tags:
-      - v*
     branches:
       - main
-  pull_request:
-
-permissions:
-  contents: read
+    tags:
+      - v*
 
 jobs:
-  nilaway:
-    name: nilaway
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3 https://github.com/actions/checkout/releases/tag/v6.0.3
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0 https://github.com/actions/setup-go/releases/tag/v6.4.0
-        with:
-          go-version: 1.25.x
-      - name: install nilaway
-        run: go install go.uber.org/nilaway/cmd/nilaway@latest
-      - name: run nilaway
-        run: nilaway ./...
+  orchestrate:
+    uses: blinklabs-io/actions/.github/workflows/reuseable-nilaway.yml@main
+    with:
+      include-pkgs: github.com/blinklabs-io/cardano-node-api

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,184 +1,28 @@
-name: publish
+# Generated automatically by org-governance-bot. Do not edit manually.
+name: "publish"
 
 on:
   push:
-    branches: ["main"]
+    branches:
+      - main
     tags:
-      - "v*.*.*"
+      - v*.*.*
 
-concurrency: ${{ github.ref }}
+permissions:
+  actions: write
+  attestations: write
+  checks: write
+  contents: write
+  id-token: write
+  packages: write
+  statuses: write
 
 jobs:
-  create-draft-release:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    outputs:
-      RELEASE_ID: ${{ steps.create-release.outputs.result }}
-    steps:
-      - run: 'echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV'
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0 https://github.com/actions/github-script/releases/tag/v9.0.0
-        id: create-release
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          result-encoding: string
-          script: |
-            try {
-              const response = await github.rest.repos.createRelease({
-                draft: true,
-                generate_release_notes: true,
-                name: process.env.RELEASE_TAG,
-                owner: context.repo.owner,
-                prerelease: false,
-                repo: context.repo.repo,
-                tag_name: process.env.RELEASE_TAG,
-              });
-
-              return response.data.id;
-            } catch (error) {
-              core.setFailed(error.message);
-            }
-
-  build-binaries:
-    strategy:
-      matrix:
-        os: [linux, darwin, freebsd, windows]
-        arch: [amd64, arm64]
-    runs-on: ubuntu-latest
-    needs: [create-draft-release]
-    permissions:
-      actions: write
-      attestations: write
-      checks: write
-      contents: write
-      id-token: write
-      packages: write
-      statuses: write
-    steps:
-      - run: 'echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV'
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3 https://github.com/actions/checkout/releases/tag/v6.0.3
-        with:
-          fetch-depth: "0"
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0 https://github.com/actions/setup-go/releases/tag/v6.4.0
-        with:
-          go-version: 1.25.x
-      - name: Build binary
-        run: GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} make build
-      - name: Upload release asset
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          _filename=cardano-node-api-${{ env.RELEASE_TAG }}-${{ matrix.os }}-${{ matrix.arch }}
-          if [[ ${{ matrix.os }} == windows ]]; then
-            _filename=${_filename}.exe
-          fi
-          cp cardano-node-api ${_filename}
-          curl \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Content-Type: application/octet-stream" \
-            --data-binary @${_filename} \
-            https://uploads.github.com/repos/${{ github.repository_owner }}/cardano-node-api/releases/${{ needs.create-draft-release.outputs.RELEASE_ID }}/assets?name=${_filename}
-      - name: Attest binary
-        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0 https://github.com/actions/attest/releases/tag/v4.1.0
-        with:
-          subject-path: "cardano-node-api"
-
-  build-images:
-    runs-on: ubuntu-latest
-    needs: [create-draft-release]
-    permissions:
-      actions: write
-      attestations: write
-      checks: write
-      contents: write
-      id-token: write
-      packages: write
-      statuses: write
-    steps:
-      - run: 'echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV'
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3 https://github.com/actions/checkout/releases/tag/v6.0.3
-        with:
-          fetch-depth: "0"
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0 https://github.com/docker/setup-qemu-action/releases/tag/v4.1.0
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0 https://github.com/docker/setup-buildx-action/releases/tag/v4.1.0
-      - name: Login to Docker Hub
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0 https://github.com/docker/login-action/releases/tag/v4.2.0
-        with:
-          username: blinklabs
-          password: ${{ secrets.DOCKER_PASSWORD }} # uses token
-      - name: Login to GHCR
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0 https://github.com/docker/login-action/releases/tag/v4.2.0
-        with:
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          registry: ghcr.io
-      - id: meta
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0 https://github.com/docker/metadata-action/releases/tag/v6.1.0
-        with:
-          images: |
-            blinklabs/cardano-node-api
-            ghcr.io/${{ github.repository }}
-          tags: |
-            # Only version, no revision
-            type=match,pattern=v(.*)-(.*),group=1
-            # branch
-            type=ref,event=branch
-            # semver
-            type=semver,pattern={{version}}
-      - name: Build images
-        id: push
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0 https://github.com/docker/build-push-action/releases/tag/v7.2.0
-        with:
-          outputs: "type=registry,push=true"
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-      - name: Attest Docker Hub image
-        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0 https://github.com/actions/attest/releases/tag/v4.1.0
-        with:
-          subject-name: index.docker.io/blinklabs/cardano-node-api
-          subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true
-      - name: Attest GHCR image
-        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0 https://github.com/actions/attest/releases/tag/v4.1.0
-        with:
-          subject-name: ghcr.io/${{ github.repository }}
-          subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true
-      # Update Docker Hub from README
-      - name: Docker Hub Description
-        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0 https://github.com/peter-evans/dockerhub-description/releases/tag/v5.0.0
-        with:
-          username: blinklabs
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: blinklabs/cardano-node-api
-          readme-filepath: ./README.md
-          short-description: "HTTP API over the Cardano Node UNIX socket"
-
-  finalize-release:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    needs: [create-draft-release, build-binaries, build-images]
-    steps:
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0 https://github.com/actions/github-script/releases/tag/v9.0.0
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            try {
-              await github.rest.repos.updateRelease({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                release_id: ${{ needs.create-draft-release.outputs.RELEASE_ID }},
-                draft: false,
-              });
-            } catch (error) {
-              core.setFailed(error.message);
-            }
-      # This updates the documentation on pkg.go.dev and the latest version available via the Go module proxy
-      - name: Pull new module version
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: andrewslotin/go-proxy-pull-action@00af8a5a49c844d6dde0bbbc116b72d8fd7ae97c # v1.5.0 https://github.com/andrewslotin/go-proxy-pull-action/releases/tag/v1.5.0
+  orchestrate:
+    uses: blinklabs-io/actions/.github/workflows/reuseable-publish.yml@main
+    secrets:
+      docker-password: ${{ secrets.DOCKER_PASSWORD }}
+    with:
+      binary-name: cardano-node-api
+      docker-image: blinklabs/cardano-node-api
+      description: "HTTP API over the Cardano Node UNIX socket"

--- a/.github/workflows/test-issue-on-close.yml
+++ b/.github/workflows/test-issue-on-close.yml
@@ -1,23 +1,14 @@
-name: Test Issue Close Trigger
-permissions:
-  contents: read
+# Generated automatically by org-governance-bot. Do not edit manually.
+name: "Test Issue Close Trigger"
+
 on:
   issues:
-    types: [closed]
+    types:
+      - closed
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Print closed issue info
-        env:
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-          ISSUE_TITLE: ${{ github.event.issue.title }}
-        run: |
-          echo "Issue Number: $ISSUE_NUMBER"
-          # Prevent workflow command injection from untrusted issue titles
-          TOKEN=$(uuidgen)
-          echo "::stop-commands::${TOKEN}"
-          echo "Title: $ISSUE_TITLE"
-          echo "::${TOKEN}::"
-          echo "Workflow triggered successfully when issue was closed."
+  orchestrate:
+    uses: blinklabs-io/actions/.github/workflows/reuseable-test-issue-on-close.yml@main
+    with:
+      issue_number: ${{ github.event.issue.number }}
+      issue_title: ${{ github.event.issue.title }}

--- a/.github/workflows/update-issue-on-close.yml
+++ b/.github/workflows/update-issue-on-close.yml
@@ -1,39 +1,18 @@
-name: Set Project Closed Date
+# Generated automatically by org-governance-bot. Do not edit manually.
+name: "Set Project Closed Date"
 
 on:
   issues:
-    types: [closed]
-
-permissions:
-  contents: read
-  issues: read
-
-env:
-  PROJECT_URL: https://github.com/orgs/blinklabs-io/projects/11
-  CLOSED_DATE_FIELD: "Closed Date"
+    types:
+      - closed
+  workflow_dispatch:
 
 jobs:
-  set-date:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Resolve closed date
-        id: when
-        shell: bash
-        run: |
-          ts='${{ github.event.issue.closed_at }}'
-          if [ -z "$ts" ] || [ "$ts" = "null" ]; then
-            d=$(date -u +%F)
-          else
-            d=$(date -u -d "$ts" +%F)
-          fi
-          echo "date=$d" >> "$GITHUB_OUTPUT"
-          echo "Closed date -> $d"
-
-      # Update the "Closed Date" field on that project item
-      - name: Update Closed Date field
-        uses: nipe0324/update-project-v2-item-field@c4af58452d1c5a788c1ea4f20e073fa722ec4a6b
-        with:
-          project-url: ${{ env.PROJECT_URL }}
-          github-token: ${{ secrets.ORG_PROJECT_PAT }}
-          field-name: ${{ env.CLOSED_DATE_FIELD }}
-          field-value: ${{ steps.when.outputs.date }}
+  orchestrate:
+    uses: blinklabs-io/actions/.github/workflows/reuseable-set-project-closed-date.yml@main
+    secrets:
+      project_pat: ${{ secrets.ORG_PROJECT_PAT }}
+    with:
+      closed_at: ${{ github.event.issue.closed_at }}
+      closed_date_field: Closed Date
+      project_url: https://github.com/orgs/blinklabs-io/projects/11


### PR DESCRIPTION
## Summary

Replaces all 8 inline workflow definitions with thin wrappers calling centrally governed reusable workflows from `blinklabs-io/actions`.

### Workflow mapping

| File | Reusable called | Key params |
|---|---|---|
| `conventional-commits.yml` | `reuseable-conventional-commits.yml@main` | — |
| `go-test.yml` | `reuseable-go-test.yml@main` | default matrix `[1.25.x, 1.26.x]` |
| `golangci-lint.yml` | `reuseable-golangci-lint.yml@main` | default go 1.25.x |
| `nilaway.yml` | `reuseable-nilaway.yml@main` | `include-pkgs: github.com/blinklabs-io/cardano-node-api` |
| `ci-docker.yml` | `reuseable-ci-docker.yml@main` | `image-name: blinklabs-io/cardano-node-api` |
| `publish.yml` | `reuseable-publish.yml@main` | `binary-name: cardano-node-api`, `docker-image: blinklabs/cardano-node-api` |
| `test-issue-on-close.yml` | `reuseable-test-issue-on-close.yml@main` | — |
| `update-issue-on-close.yml` | `reuseable-set-project-closed-date.yml@main` | project 11 |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced eight inline GitHub Actions with thin wrappers that call reusable workflows from `blinklabs-io/actions`. This centralizes CI/CD and reduces maintenance with no behavior change; also fixes Docker CI to trigger on `Makefile` and `openapi/**` changes.

- **Refactors**
  - Migrated: conventional-commits, go-test, golangci-lint, nilaway, Docker CI, publish, and two issue-close workflows.
  - Key params: go-test matrix [1.25.x, 1.26.x]; golangci-lint Go 1.25.x; nilaway include-pkgs `github.com/blinklabs-io/cardano-node-api`; Docker CI image `blinklabs-io/cardano-node-api` and path triggers include `Makefile` and `openapi/**`; publish binary `cardano-node-api`, docker image `blinklabs/cardano-node-api`, description set; project closed-date uses project 11.
  - Notes: added “Generated automatically by org-governance-bot” headers; required secrets unchanged (`DOCKER_PASSWORD`, `ORG_PROJECT_PAT`).

<sup>Written for commit e501c1e99cfc7b5caa6093e9457fc57b18c45d9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/cardano-node-api/pull/602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

